### PR TITLE
README: fix link to examples folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ see [sensitive state][sensitive-state].**
 
 ## Examples
 
-For more examples, please see the [examples][examples] folder in this
+For more examples, please see the [examples](examples/) folder in this
 repository.
 
 ## Reference


### PR DESCRIPTION
The examples link wasn't pointing to the examples directory. Update the link style to match the link to the docs directory.