### PR TITLE
Update README.md to include required_providers explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ see [sensitive state][sensitive-state].**
 
 1. If you haven't already, [bootstrap berglas](https://github.com/GoogleCloudPlatform/berglas#setup)
 
+#### Optionally
+
+If using terraform v0.13+ you can create a `versions.tf` file to pull the plugin during `terraform init` without installing it locally
+```hcl
+    terraform {
+      required_providers {
+        berglas = {
+          source  = "sethvargo/berglas"
+          version = "0.1.0"
+        }
+      }
+    }
+```
+
 
 ## Usage
 


### PR DESCRIPTION
Added a small section to show how the plugin can also automatically be pulled using the `required_provider` block from terraform v0.13+

Makes it easier for some people so it does not have to be manually installed.